### PR TITLE
Fixing warnings

### DIFF
--- a/alphabet_cipher/config/config.exs
+++ b/alphabet_cipher/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/alphabet_cipher/mix.exs
+++ b/alphabet_cipher/mix.exs
@@ -7,7 +7,7 @@ defmodule AlphabetCipher.Mixfile do
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/card_game_war/config/config.exs
+++ b/card_game_war/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/card_game_war/lib/game.ex
+++ b/card_game_war/lib/game.ex
@@ -4,8 +4,8 @@ defmodule CardGameWar.Game do
   def suits, do: [:spade, :club, :diamond, :heart]
   def ranks, do: [2, 3, 4, 5, 6, 7, 8, 9, 10, :jack, :queen, :king, :ace]
   def cards do
-    for suit <- suits,
-        rank <- ranks do
+    for suit <- suits(),
+        rank <- ranks() do
       {suit, rank}
     end
   end

--- a/card_game_war/mix.exs
+++ b/card_game_war/mix.exs
@@ -7,7 +7,7 @@ defmodule CardGameWar.Mixfile do
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/doublets/config/config.exs
+++ b/doublets/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/doublets/mix.exs
+++ b/doublets/mix.exs
@@ -7,7 +7,7 @@ defmodule Doublets.Mixfile do
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/fox_goose_bag_of_corn/config/config.exs
+++ b/fox_goose_bag_of_corn/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/fox_goose_bag_of_corn/lib/puzzle.ex
+++ b/fox_goose_bag_of_corn/lib/puzzle.ex
@@ -13,8 +13,8 @@ defmodule FoxGooseBagOfCorn.Puzzle do
     ] 
   end
 
-  def to_set(list) when is_list(list), do: Enum.into(list, HashSet.new)
-  def step_to_sets(step), do: step |> Enum.map &to_set/1
+  def to_set(list) when is_list(list), do: Enum.into(list, MapSet.new)
+  def step_to_sets(step), do: step |> Enum.map(&to_set/1)
 
   @doc """
     Defines a sigil for a HashSet of atoms

--- a/fox_goose_bag_of_corn/mix.exs
+++ b/fox_goose_bag_of_corn/mix.exs
@@ -7,7 +7,7 @@ defmodule FoxGooseBagOfCorn.Mixfile do
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/fox_goose_bag_of_corn/test/puzzle_test.exs
+++ b/fox_goose_bag_of_corn/test/puzzle_test.exs
@@ -4,13 +4,13 @@ defmodule FoxGooseBagOfCorn.PuzzleTest do
   import  FoxGooseBagOfCorn.Puzzle
 
   def validate_move(new_step, prev_step) do
-    diff1 = Set.difference prev_step, new_step
-    diff2 = Set.difference new_step, prev_step
-    diffs = Set.union diff1, diff2
-    diff_num = Set.size diffs
+    diff1 = MapSet.difference prev_step, new_step
+    diff2 = MapSet.difference new_step, prev_step
+    diffs = MapSet.union diff1, diff2
+    diff_num = MapSet.size diffs
     assert 3 > diff_num
     if diff_num > 0 do
-      assert Set.member?(diffs, :you)
+      assert MapSet.member?(diffs, :you)
     end
     new_step
   end
@@ -18,15 +18,15 @@ defmodule FoxGooseBagOfCorn.PuzzleTest do
   def assert_equal_list_of_sets(expected, calculated) do
     assert length(expected) == length(calculated)
     Enum.zip(expected, calculated)
-      |> Enum.each fn {exp, calc} -> 
-           assert Set.equal?(exp, calc) 
-         end
+      |> Enum.each(fn {exp, calc} -> 
+           assert MapSet.equal?(exp, calc) 
+         end)
   end
 
   def nth_column(mtx, n), do: mtx |> Enum.map(&Enum.at(&1,n))
 
   setup_all do
-    plan       = river_crossing_plan |> Enum.map(&step_to_sets/1)
+    plan       = river_crossing_plan() |> Enum.map(&step_to_sets/1)
     left_bank  = plan |> nth_column(0)
     right_bank = plan |> nth_column(2)
     {:ok, plan: plan, left_bank: left_bank, right_bank: right_bank}
@@ -34,39 +34,39 @@ defmodule FoxGooseBagOfCorn.PuzzleTest do
 
   test "you begin with the fox, goose and corn on one side of the river", %{plan: plan} do
     expected   = [~H":you :fox :goose :corn", ~H":boat", ~H""]
-    calculated = plan |> List.first
+    calculated = plan |> List.first()
     assert_equal_list_of_sets(expected, calculated) 
   end
 
   test "you end with the fox, goose and corn on one side of the river", %{plan: plan} do
     expected   = [~H"", ~H":boat", ~H":you :fox :goose :corn"]
-    calculated = plan |> List.last
+    calculated = plan |> List.last()
     assert_equal_list_of_sets(expected, calculated) 
   end
 
   test "the fox and the goose should never be left alone together", %{left_bank: left, right_bank: right} do
     assert left ++ right
-           |> Enum.filter(&Set.equal?(~H":fox :goose", &1))
-           |> Enum.empty?
+           |> Enum.filter(&MapSet.equal?(~H":fox :goose", &1))
+           |> Enum.empty?()
   end
 
   test "the goose and the corn should never be left alone together", %{left_bank: left, right_bank: right} do
     assert left ++ right
-           |> Enum.filter(&Set.equal?(~H":goose :corn", &1))
-           |> Enum.empty?
+           |> Enum.filter(&MapSet.equal?(~H":goose :corn", &1))
+           |> Enum.empty?()
   end
 
   test "The boat can carry only you plus one other", %{plan: plan} do
     assert plan 
            |> nth_column(1)
-           |> Enum.filter(&Set.size(&1) > 3)
-           |> Enum.empty?
+           |> Enum.filter(&MapSet.size(&1) > 3)
+           |> Enum.empty?()
   end
 
   test "Moves are valid", %{plan: plan} do
-    0..2 |> Enum.each fn(idx) ->
+    0..2 |> Enum.each(fn(idx) ->
               plan |> nth_column(idx)
                    |> Enum.reduce(&validate_move/2)
-            end
+            end)
   end
 end

--- a/magic_square/config/config.exs
+++ b/magic_square/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/magic_square/mix.exs
+++ b/magic_square/mix.exs
@@ -7,7 +7,7 @@ defmodule MagicSquare.Mixfile do
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/magic_square/test/puzzle_test.exs
+++ b/magic_square/test/puzzle_test.exs
@@ -3,13 +3,13 @@ defmodule MagicSquare.PuzzleTest do
   import MagicSquare.Puzzle
 
   test "all the rows, columns, and diagonal add to the same number" do
-    square   = magic_square values
-    sum_rows = sum_rows(square)      |> Enum.into(HashSet.new)
-    sum_cols = sum_cols(square)      |> Enum.into(HashSet.new)
-    sum_diag = sum_diagonals(square) |> Enum.into(HashSet.new)
+    square   = magic_square values()
+    sum_rows = sum_rows(square)      |> Enum.into(MapSet.new)
+    sum_cols = sum_cols(square)      |> Enum.into(MapSet.new)
+    sum_diag = sum_diagonals(square) |> Enum.into(MapSet.new)
 
-    Enum.each [sum_rows, sum_cols, sum_diag], &(assert 1 == Set.size(&1))
-    assert Set.equal? sum_rows, sum_cols
-    assert Set.equal? sum_rows, sum_diag
+    Enum.each [sum_rows, sum_cols, sum_diag], &(assert 1 == MapSet.size(&1))
+    assert MapSet.equal? sum_rows, sum_cols
+    assert MapSet.equal? sum_rows, sum_diag
   end
 end

--- a/tiny_maze/config/config.exs
+++ b/tiny_maze/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/tiny_maze/mix.exs
+++ b/tiny_maze/mix.exs
@@ -7,7 +7,7 @@ defmodule TinyMaze.Mixfile do
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/wonderland_number/config/config.exs
+++ b/wonderland_number/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/wonderland_number/mix.exs
+++ b/wonderland_number/mix.exs
@@ -7,7 +7,7 @@ defmodule WonderlandNumber.Mixfile do
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/wonderland_number/test/finder_test.exs
+++ b/wonderland_number/test/finder_test.exs
@@ -3,20 +3,20 @@ defmodule WonderlandNumber.FinderTest do
   import WonderlandNumber.Finder
 
   def to_charset(n) do
-    n |> Integer.to_string 
-      |> to_char_list 
-      |> Enum.map(&[&1]) 
-      |> Enum.into(HashSet.new)
+    n |> Integer.to_string()
+      |> to_charlist()
+      |> Enum.map(&[&1])
+      |> Enum.into(MapSet.new)
   end
 
   def has_all_the_same_digits?(n1, n2) do
     s1 = to_charset n1
     s2 = to_charset n2
-    Set.equal? s1, s2
+    MapSet.equal? s1, s2
   end
 
   test "A wonderland number must have the following things true about it" do
-    wondernum = wonderland_number
+    wondernum = wonderland_number()
     assert 6 == wondernum |> Integer.to_string |> String.length
     assert has_all_the_same_digits? wondernum, (2 * wondernum)
     assert has_all_the_same_digits? wondernum, (3 * wondernum)


### PR DESCRIPTION
Hi! I just noticed some deprecation warnings while running the katas. The fixes are pretty straight forward.

* Changed `Mix.Config` to `Config`
* Changed `Set` and `HashSet` to `MapSet`
* Added parenthesis for function calls with no parameters